### PR TITLE
Update Analytics example to work with ZappAnalyticsPluginsSDK

### DIFF
--- a/AnalyticsPlugin/iOS/Podfile
+++ b/AnalyticsPlugin/iOS/Podfile
@@ -7,8 +7,8 @@ source 'git@github.com:applicaster/PluginsBuilderCocoaPods.git'
 source 'git@github.com:CocoaPods/Specs.git'
 
 def shared_pods
-pod 'ZappPlugins'
-pod 'ApplicasterSDK'
+pod 'ZappAnalyticsPluginsSDK'
+pod 'ApplicasterSDK', '~> 7.2.0'
 pod 'GoogleAnalytics'
 end
 

--- a/AnalyticsPlugin/iOS/README.md
+++ b/AnalyticsPlugin/iOS/README.md
@@ -6,12 +6,14 @@ If you are not familiar with Zapp please visit [our website](http://applicaster.
 
 The full [Zapp](http://zapp.applicaster.com) plugins documentation is available [here](https://developer-zapp.applicaster.com).
 
+When you are starting a new iOS plugin our recommendation is to install our [Xcode templates for Applicaster plugins](https://github.com/applicaster/zapp-plugins-ios-templates). The templates will enable you to chose the plugin type in the Xcode "new project" screen. After selecting the plugin type, you will need to provide few general details on the plugin. Then, it will generate a new plugin project that includes the deployment files, like podspec and the plugin_manifest.json, and the plugin class itself including the relevant Zapp protocol.
+
 ## Getting Started
 Clone this project `$ git clone https://github.com/applicaster/zapp-plugins-examples`.
 
 CD into `zapp-plugins-examples/Analytics/iOS` 
 
-Run `$ pod install` in order to set the workspace.
+Run `$ pod update` in order to set the workspace.
 
 Open `ZappAnalyticsPluginExample-iOS.xcworkspace` with Xcode 8.3.3 or above.
 
@@ -20,13 +22,11 @@ The Zapp analytics plugin API enables developers to integrate different analytic
 
 The API contains the `ZPAnalyticsProvider` protocol which should be implemented by your provider.
 
-In order to access the `ZPAnalyticsProvider`, you will need to import `ApplicasterSDK` and the `ZappPlugins` frameworks, for example:
+In order to access the `ZPAnalyticsProvider`, you will need to import  `ZappAnalyticsPluginsSDK`  which include the `ZPAnalyticsProvider` and the relevant protocol, for example:
 
 ```
 import Foundation
-import ZappPlugins
-import ApplicasterSDK
-import AVKit
+import ZappAnalyticsPluginsSDK
 ```
 
 ### ZPAnalyticsProvider
@@ -125,7 +125,7 @@ import AVKit
     
 
 #### Using the Zapp Plugin Configuration JSON
-When creating a plugin in Zapp we can create custom configuration fields. This enable the Zapp user to fill relevant details for the specific plugin. More details can found in the [Zapp Plugin Manifest Format](http://zapp-tech-book.herokuapp.com/zappifest/plugins-manifest-format.html).
+When creating a plugin in Zapp we can create custom configuration fields. This enable the Zapp user to fill relevant details for the specific plugin. More details can found in the [Zapp guide for deploy and submit](https://developer-zapp.applicaster.com/getting-started/deploy-and-submit.html).
 You can use these configuration in the configureProvider function like so:
 
 ```
@@ -134,9 +134,3 @@ if let value = self.providerProperties["some_custom_config_key"] as? String {
 }
 ```
 
-## Debug
-In order to be able to test and debug your project A->Z, you will need add your plugin to the `zapp-ios-plugins-starter-kit`, which can be cloned [here](https://github.com/applicaster/zapp-ios-plugins-starter-kit).
-
-## TO-DOs
-- [ ] readme improvements:
-    - add details about the `zapp-ios-plugins-starter-kit`

--- a/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS.xcodeproj/project.pbxproj
+++ b/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		3B00410E211B81DC0071C859 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3B004116211BD6720071C859 /* TestAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAnalyticsProvider.swift; sourceTree = "<group>"; };
 		3B004119211BD9A80071C859 /* ZappAnalyticsPluginExample-iOS-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZappAnalyticsPluginExample-iOS-Bridging-Header.h"; sourceTree = "<group>"; };
+		BBC0F465213D394000170783 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		E6FA73731C29202689C02A43 /* Pods-ZappAnalyticsPluginExample-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAnalyticsPluginExample-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAnalyticsPluginExample-iOS/Pods-ZappAnalyticsPluginExample-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -73,6 +74,7 @@
 		3B004101211B81DB0071C859 /* ZappAnalyticsPluginExample-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				BBC0F465213D394000170783 /* README.md */,
 				3B004102211B81DB0071C859 /* AppDelegate.swift */,
 				3B004104211B81DB0071C859 /* ViewController.swift */,
 				3B004116211BD6720071C859 /* TestAnalyticsProvider.swift */,
@@ -184,7 +186,11 @@
 				"${BUILT_PRODUCTS_DIR}/Toaster/Toaster.framework",
 				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
+				"${PODS_ROOT}/ZappAnalyticsPluginsSDK/ZappAnalyticsPluginsSDK.framework",
+				"${PODS_ROOT}/ZappGeneralPluginsSDK/ZappGeneralPluginsSDK.framework",
+				"${PODS_ROOT}/ZappLoginPluginsSDK/ZappLoginPluginsSDK.framework",
 				"${PODS_ROOT}/ZappPlugins/ZappPlugins.framework",
+				"${PODS_ROOT}/ZappPushPluginsSDK/ZappPushPluginsSDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -202,7 +208,11 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toaster.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappAnalyticsPluginsSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappGeneralPluginsSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappLoginPluginsSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPlugins.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPushPluginsSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS/TestAnalyticsProvider.swift
+++ b/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS/TestAnalyticsProvider.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import ZappPlugins
-import ApplicasterSDK
+import ZappAnalyticsPluginsSDK
 
 open class TestAnalyticsProvider: ZPAnalyticsProvider {
     

--- a/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS/ViewController.swift
+++ b/AnalyticsPlugin/iOS/ZappAnalyticsPluginExample-iOS/ViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import ZappPlugins
 import ApplicasterSDK
 
 class ViewController: UIViewController {


### PR DESCRIPTION
This PR is updating the analytics example to work with the new `ZappAnalyticsPluginsSDK` framework. 
The `ZappAnalyticsPluginsSDK` is including the analytics protocols and replacing the `ZappPlugins` framework in that. 
In addition, this PR also remove the use of `ApplicasterSDK` in the adapter itself.