### PR TITLE
Updating iOS examples to Xcode10

### DIFF
--- a/AnalyticsPlugin/iOS/Podfile
+++ b/AnalyticsPlugin/iOS/Podfile
@@ -8,7 +8,7 @@ source 'git@github.com:CocoaPods/Specs.git'
 
 def shared_pods
 pod 'ZappAnalyticsPluginsSDK'
-pod 'ApplicasterSDK', '~> 7.0'
+pod 'ApplicasterSDK', '~> 7.3'
 pod 'GoogleAnalytics'
 end
 

--- a/AnalyticsPlugin/iOS/Podfile
+++ b/AnalyticsPlugin/iOS/Podfile
@@ -8,7 +8,7 @@ source 'git@github.com:CocoaPods/Specs.git'
 
 def shared_pods
 pod 'ZappAnalyticsPluginsSDK'
-pod 'ApplicasterSDK', '~> 7.2.0'
+pod 'ApplicasterSDK', '~> 7.0'
 pod 'GoogleAnalytics'
 end
 

--- a/AnalyticsPlugin/iOS/README.md
+++ b/AnalyticsPlugin/iOS/README.md
@@ -15,7 +15,7 @@ CD into `zapp-plugins-examples/Analytics/iOS`
 
 Run `$ pod update` in order to set the workspace.
 
-Open `ZappAnalyticsPluginExample-iOS.xcworkspace` with Xcode 8.3.3 or above.
+Open `ZappAnalyticsPluginExample-iOS.xcworkspace` with Xcode 10.
 
 ## Zapp Analytics Provider API
 The Zapp analytics plugin API enables developers to integrate different analytic providers (i.e Google Analytics, Firebase, etc) to the the Zapp Platform.

--- a/LoginPlugin/iOS/Podfile
+++ b/LoginPlugin/iOS/Podfile
@@ -13,7 +13,7 @@ end
 
 def shared_pods
     pod 'ZappLoginPluginsSDK'
-    pod 'ApplicasterSDK', '~> 7.2.0'
+    pod 'ApplicasterSDK', '~> 7.0'
     pod 'FacebookCore'
     pod 'FacebookLogin'
 end

--- a/LoginPlugin/iOS/Podfile
+++ b/LoginPlugin/iOS/Podfile
@@ -13,7 +13,7 @@ end
 
 def shared_pods
     pod 'ZappLoginPluginsSDK'
-    pod 'ApplicasterSDK', '~> 7.0'
+    pod 'ApplicasterSDK', '~> 7.3'
     pod 'FacebookCore'
     pod 'FacebookLogin'
 end

--- a/LoginPlugin/iOS/README.md
+++ b/LoginPlugin/iOS/README.md
@@ -13,7 +13,7 @@ Clone this project `$ git clone https://github.com/applicaster/zapp-plugins-exam
 and navigate to LoginPlugin -> iOS
 Run `$ pod update` in order to set the workspace.
 
-Open `ZappLoginPluginExample-iOS.xcworkspace` with Xcode 9.4.
+Open `ZappLoginPluginExample-iOS.xcworkspace` with Xcode 10.
 
 ## Zapp Login Plugin API
 The Zapp login plugin API enables developers to integrate different login providers to the the Zapp Platform.

--- a/URLSchemeBasedGeneralPlugin/iOS/Podfile
+++ b/URLSchemeBasedGeneralPlugin/iOS/Podfile
@@ -4,6 +4,7 @@ install! 'cocoapods', :deterministic_uuids => false
 
 source 'git@github.com:applicaster/CocoaPods.git'
 source 'git@github.com:CocoaPods/Specs.git'
+source 'git@github.com:applicaster/PluginsBuilderCocoaPods.git'
 
 def shared_pods
 pod 'ZappPlugins'

--- a/URLSchemeBasedGeneralPlugin/iOS/SampleGeneralPlugin.podspec
+++ b/URLSchemeBasedGeneralPlugin/iOS/SampleGeneralPlugin.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
       "SampleGeneralPluginResources/**/*.xib",
       "SampleGeneralPluginResources/**/*.png"
     ]
+    c.dependency 'ZappGeneralPluginsSDK'
     c.dependency 'ZappPlugins'
   end
 

--- a/URLSchemeBasedGeneralPlugin/iOS/SampleGeneralPlugin/SampleGeneralPlugin.swift
+++ b/URLSchemeBasedGeneralPlugin/iOS/SampleGeneralPlugin/SampleGeneralPlugin.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ZappPlugins
+import ZappGeneralPluginsSDK
 
 @objc public class SampleGeneralPlugin: ZPGeneralBaseProvider {
     

--- a/URLSchemeBasedGeneralPlugin/iOS/ZappGeneralPluginExample-iOS.xcodeproj/project.pbxproj
+++ b/URLSchemeBasedGeneralPlugin/iOS/ZappGeneralPluginExample-iOS.xcodeproj/project.pbxproj
@@ -164,10 +164,12 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ZappGeneralPluginExample-iOS/Pods-ZappGeneralPluginExample-iOS-frameworks.sh",
+				"${PODS_ROOT}/ZappGeneralPluginsSDK/ZappGeneralPluginsSDK.framework",
 				"${PODS_ROOT}/ZappPlugins/ZappPlugins.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappGeneralPluginsSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPlugins.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -349,10 +351,14 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ZappGeneralPluginExample-iOS/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.applicaster.ZappGeneralPluginExample-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -365,10 +371,14 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ZappGeneralPluginExample-iOS/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.applicaster.ZappGeneralPluginExample-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/URLSchemeBasedGeneralPlugin/iOS/readme.md
+++ b/URLSchemeBasedGeneralPlugin/iOS/readme.md
@@ -12,7 +12,7 @@ In this example the only implemented call is `func handleUrlScheme(_ params: NSD
 
 ## Project setup
 * Run `pod update` in the main library
-* Open `ZappGeneralPluginExample-iOS.xcWorkspace`
+* Open `ZappGeneralPluginExample-iOS.xcWorkspace` with Xcode 10.
 * Hit run
 
 There are 2 buttons:

--- a/VideoPlayer/iOS/Podfile
+++ b/VideoPlayer/iOS/Podfile
@@ -8,7 +8,7 @@ source 'git@github.com:CocoaPods/Specs.git'
 
 def shared_pods
 pod 'ZappPlugins'
-pod 'ApplicasterSDK', '~> 7.0'
+pod 'ApplicasterSDK', '~> 7.3'
 pod 'ZappAppConnector'
 
 end

--- a/VideoPlayer/iOS/Podfile
+++ b/VideoPlayer/iOS/Podfile
@@ -8,7 +8,7 @@ source 'git@github.com:CocoaPods/Specs.git'
 
 def shared_pods
 pod 'ZappPlugins'
-pod 'ApplicasterSDK'
+pod 'ApplicasterSDK', '~> 7.0'
 pod 'ZappAppConnector'
 
 end
@@ -20,7 +20,7 @@ end
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
-            config.build_settings['SWIFT_VERSION'] = '4.0'
+            config.build_settings['SWIFT_VERSION'] = '4.1'
         end
     end
 end

--- a/VideoPlayer/iOS/README.md
+++ b/VideoPlayer/iOS/README.md
@@ -11,7 +11,7 @@ Clone this project `$ git clone https://github.com/applicaster/ZappPluginPlayerE
 
 Run `$ pod install` in order to set the workspace.
 
-Open `ZappPluginPlayerExample-iOS.xcworkspace` with Xcode 8.3.3 or above.
+Open `ZappPluginPlayerExample-iOS.xcworkspace` with Xcode 10.
 
 ## Zapp Plugin Player API
 The Zapp plugin player API enables developers to integrate different players to the the Zapp Platform.

--- a/VideoPlayer/iOS/ZappPluginPlayerExample-iOS.xcodeproj/project.pbxproj
+++ b/VideoPlayer/iOS/ZappPluginPlayerExample-iOS.xcodeproj/project.pbxproj
@@ -174,7 +174,6 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ZappPluginPlayerExample-iOS/Pods-ZappPluginPlayerExample-iOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
-				"${BUILT_PRODUCTS_DIR}/APSiren/APSiren.framework",
 				"${PODS_ROOT}/ApplicasterSDK/ApplicasterSDK.framework",
 				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
@@ -182,23 +181,22 @@
 				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSDKLoginKit/FBSDKLoginKit.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSDKShareKit/FBSDKShareKit.framework",
-				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage_Applicaster/FLAnimatedImage_Applicaster.framework",
-				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
-				"${PODS_ROOT}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds/GoogleInteractiveMediaAds.framework",
-				"${BUILT_PRODUCTS_DIR}/MPNotificationView_Applicaster/MPNotificationView_Applicaster.framework",
-				"${BUILT_PRODUCTS_DIR}/NKJWT/NKJWT.framework",
-				"${BUILT_PRODUCTS_DIR}/SHMKit_Applicaster/SHMKit_Applicaster.framework",
+				"${PODS_ROOT}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework",
 				"${BUILT_PRODUCTS_DIR}/SSZipArchive/SSZipArchive.framework",
 				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
 				"${BUILT_PRODUCTS_DIR}/Toaster/Toaster.framework",
-				"${BUILT_PRODUCTS_DIR}/ZappHelpers/ZappHelpers.framework",
+				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
+				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
+				"${PODS_ROOT}/ZappAnalyticsPluginsSDK/ZappAnalyticsPluginsSDK.framework",
+				"${BUILT_PRODUCTS_DIR}/ZappAppConnector/ZappAppConnector.framework",
+				"${PODS_ROOT}/ZappGeneralPluginsSDK/ZappGeneralPluginsSDK.framework",
+				"${PODS_ROOT}/ZappLoginPluginsSDK/ZappLoginPluginsSDK.framework",
 				"${PODS_ROOT}/ZappPlugins/ZappPlugins.framework",
-				"${PODS_ROOT}/e-planning/e_planning.framework",
+				"${PODS_ROOT}/ZappPushPluginsSDK/ZappPushPluginsSDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/APSiren.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ApplicasterSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bolts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
@@ -206,18 +204,18 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKLoginKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKShareKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage_Applicaster.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleInteractiveMediaAds.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MPNotificationView_Applicaster.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NKJWT.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SHMKit_Applicaster.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toaster.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappHelpers.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappAnalyticsPluginsSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappAppConnector.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappGeneralPluginsSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappLoginPluginsSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPlugins.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/e_planning.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPushPluginsSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -231,13 +229,13 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ZappPluginPlayerExample-iOS/Pods-ZappPluginPlayerExample-iOS-resources.sh",
-				$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle,
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterKitResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterShareExtensionUIResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Updating Podlife's and Podspec's to use ApplicasterSDK that support Xcode10 and above.
Updating some README's.
Updating the iOS general plugin example to work with the new `ZappGeneralPluginsSDK`.