### PR TITLE
fix: Update Zapp Login Plugin example - iOS to current SDK

### DIFF
--- a/FullScreen/android/app/build.gradle
+++ b/FullScreen/android/app/build.gradle
@@ -22,6 +22,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.applicaster:applicaster-android-sdk:2.29.25'
+    implementation 'com.applicaster:applicaster-android-sdk:2.33.20'
+    implementation 'com.google.dagger:dagger:2.8'
     implementation project(':testfullscreenplugin-android')
 }

--- a/LoginPlugin/iOS/Podfile
+++ b/LoginPlugin/iOS/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 use_frameworks!
 install! 'cocoapods', :deterministic_uuids => false
 
@@ -13,9 +13,10 @@ end
 
 def shared_pods
     pod 'ZappLoginPluginsSDK'
-    pod 'ApplicasterSDK', '~> 7.3'
     pod 'FacebookCore'
     pod 'FacebookLogin'
+    pod 'FBSDKCoreKit', '= 4.38.0'
+    pod 'FBSDKLoginKit', '= 4.38.0'
 end
 
 target 'ZappLoginPluginExample-iOS' do
@@ -25,7 +26,7 @@ end
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
-            config.build_settings['SWIFT_VERSION'] = '4.1'
+            config.build_settings['SWIFT_VERSION'] = '4.2'
         end
     end
 end

--- a/LoginPlugin/iOS/README.md
+++ b/LoginPlugin/iOS/README.md
@@ -23,7 +23,6 @@ In order to access the `ZPLoginProviderProtocol` and the `ZPLoginProviderUserDat
 ``` swift
 import Foundation
 import ZappLoginPluginsSDK
-import ApplicasterSDK
 ```
 
 ### ZPLoginProviderProtocol
@@ -37,7 +36,7 @@ import ApplicasterSDK
         self.loginManager = LoginManager()
         self.configurationJSON = configurationJSON
     }
-    
+
     /**
      This method is being called after the isAuthenticated() method returned a false value, meaning, the user is not 		 logged in, It starts the login process.
      The completion should always be called when the process is done - no matter what is the result.
@@ -67,7 +66,7 @@ import ApplicasterSDK
             completion(.failed)
         }
     }
-    
+
     /**
      This method is being called in order to start logout process.
      The completion should always be called when the process is done - no matter what is the result.
@@ -80,7 +79,7 @@ import ApplicasterSDK
             completion(.failed)
         }
     }
-    
+
     /**
      This methood is called in order to verify if we need to start a login flow
      for example play method is invoked on a player, the player first checks if a login plugin exist
@@ -99,7 +98,7 @@ import ApplicasterSDK
         }
         return retVal
     }
-    
+
 	/**
      This methood is called in order to verify if authorization flow is in process
     */
@@ -120,7 +119,7 @@ import ApplicasterSDK
         }
         return token
     }
-    
+
     /**
      Setter for the user Token - usually set after login success
      @Params: the authentication recieved when login successfuly
@@ -128,10 +127,10 @@ import ApplicasterSDK
     public func setUserToken(token: String?) {
         UserDefaults.standard.set(token, forKey: "fb_login_token")
     }
-    
+
     /**
      This methood is called in order to verify if we need to start a login flow with respect to the policies dictionary
-     @params policies - dictionary containing policies to be considered when returning the result 
+     @params policies - dictionary containing policies to be considered when returning the result
      Returns bool value indicating if the user is already verified if not  we start the login proccess
      in this example we check if the login token exists and if it is valid
     */

--- a/LoginPlugin/iOS/README.md
+++ b/LoginPlugin/iOS/README.md
@@ -19,9 +19,8 @@ Open `ZappLoginPluginExample-iOS.xcworkspace` with Xcode 10.
 The Zapp login plugin API enables developers to integrate different login providers to the the Zapp Platform.
 
 The API contains the `ZPLoginProviderProtocol` and `ZPLoginProviderUserDataProtocol`
-In order to access the `ZPLoginProviderProtocol` and the `ZPLoginProviderUserDataProtocol`, you will need to import `ApplicasterSDK` and the `ZappLoginPluginsSDK` frameworks, for example:
+In order to access the `ZPLoginProviderProtocol` and the `ZPLoginProviderUserDataProtocol`, you will need to import the `ZappLoginPluginsSDK` framework, for example:
 ``` swift
-import Foundation
 import ZappLoginPluginsSDK
 ```
 

--- a/LoginPlugin/iOS/ZappLoginPluginExample-iOS.podspec
+++ b/LoginPlugin/iOS/ZappLoginPluginExample-iOS.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author           = { "Udi Lumnitz" => "u.lumnitz@applicaster.com" }
   s.source           = { :git => "git@github.com:applicaster/ZappLoginPluginExample-iOS.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '10.0'
   s.requires_arc = true
 
   s.public_header_files = 'ZappLoginPluginExample-iOS/**/*.h'
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
                   "ZappLoginPluginExample-iOS/**/*.png"]
 
   s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-                  'ENABLE_BITCODE' => 'NO',
                   'OTHER_LDFLAGS' => '$(inherited)',
                   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}"/**',
                   'LIBRARY_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}"/**'

--- a/LoginPlugin/iOS/ZappLoginPluginExample-iOS.xcodeproj/project.pbxproj
+++ b/LoginPlugin/iOS/ZappLoginPluginExample-iOS.xcodeproj/project.pbxproj
@@ -135,7 +135,6 @@
 				BB7EA43A1EF7B37E00B1422C /* Resources */,
 				FABD722F1F6155C700A1FD18 /* Copy app resources */,
 				59EC32A1CA825A046F7F8C30 /* [CP] Embed Pods Frameworks */,
-				77D9681A66F6C79A167D4B11 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -167,6 +166,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -204,75 +204,29 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ZappLoginPluginExample-iOS/Pods-ZappLoginPluginExample-iOS-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
-				"${PODS_ROOT}/ApplicasterSDK/ApplicasterSDK.framework",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FBNotifications/FBNotifications.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSDKLoginKit/FBSDKLoginKit.framework",
-				"${BUILT_PRODUCTS_DIR}/FBSDKShareKit/FBSDKShareKit.framework",
 				"${BUILT_PRODUCTS_DIR}/FacebookCore/FacebookCore.framework",
 				"${BUILT_PRODUCTS_DIR}/FacebookLogin/FacebookLogin.framework",
-				"${PODS_ROOT}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework",
-				"${BUILT_PRODUCTS_DIR}/SSZipArchive/SSZipArchive.framework",
-				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
-				"${BUILT_PRODUCTS_DIR}/Toaster/Toaster.framework",
-				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
-				"${PODS_ROOT}/ZappAnalyticsPluginsSDK/ZappAnalyticsPluginsSDK.framework",
-				"${PODS_ROOT}/ZappGeneralPluginsSDK/ZappGeneralPluginsSDK.framework",
 				"${PODS_ROOT}/ZappLoginPluginsSDK/ZappLoginPluginsSDK.framework",
 				"${PODS_ROOT}/ZappPlugins/ZappPlugins.framework",
-				"${PODS_ROOT}/ZappPushPluginsSDK/ZappPushPluginsSDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ApplicasterSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bolts.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBNotifications.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKLoginKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKShareKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookLogin.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleInteractiveMediaAds.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toaster.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappAnalyticsPluginsSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappGeneralPluginsSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappLoginPluginsSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPlugins.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZappPushPluginsSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ZappLoginPluginExample-iOS/Pods-ZappLoginPluginExample-iOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		77D9681A66F6C79A167D4B11 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ZappLoginPluginExample-iOS/Pods-ZappLoginPluginExample-iOS-resources.sh",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterKitResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterShareExtensionUIResources.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ZappLoginPluginExample-iOS/Pods-ZappLoginPluginExample-iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7A0875516635C4D74A16E856 /* [CP] Check Pods Manifest.lock */ = {
@@ -385,13 +339,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -431,11 +385,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -451,7 +405,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.applicaster.ZappPluginPlayerExample-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -465,7 +418,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.applicaster.ZappPluginPlayerExample-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/LoginPlugin/iOS/ZappLoginPluginExample-iOS/AppDelegate.swift
+++ b/LoginPlugin/iOS/ZappLoginPluginExample-iOS/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/LoginPlugin/iOS/ZappLoginPluginExample-iOS/FacebookLoginPlugin.swift
+++ b/LoginPlugin/iOS/ZappLoginPluginExample-iOS/FacebookLoginPlugin.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ZappLoginPluginsSDK
-import ApplicasterSDK
 import FacebookCore
 import FacebookLogin
 

--- a/LoginPlugin/iOS/ZappLoginPluginExample-iOS/SelectionScreenViewController.swift
+++ b/LoginPlugin/iOS/ZappLoginPluginExample-iOS/SelectionScreenViewController.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-import ApplicasterSDK
 import ZappLoginPluginsSDK
 
 /*


### PR DESCRIPTION
This PR updates and fixes compilation of the example plugin.
Also remove use of Applicaster SDK as it's not really needed and shouldn't be required.